### PR TITLE
Set source to 'segment' when tracking events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ Vero.prototype.track = function(track) {
   if (track.event().match(regex)) {
     push('unsubscribe', { id: track.properties().id });
   } else {
-    push('track', track.event(), track.properties());
+    push('track', track.event(), track.properties(), { source: 'segment' });
   }
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -120,12 +120,12 @@ describe('Vero', function() {
 
       it('should send an event', function() {
         analytics.track('event');
-        analytics.called(window._veroq.push, ['track', 'event', {}]);
+        analytics.called(window._veroq.push, ['track', 'event', {}, { source: 'segment' }]);
       });
 
       it('should send an event and properties', function() {
         analytics.track('event', { property: true });
-        analytics.called(window._veroq.push, ['track', 'event', { property: true }]);
+        analytics.called(window._veroq.push, ['track', 'event', { property: true }, { source: 'segment' }]);
       });
 
       it('should send an unsubscribe event in the correct format', function() {


### PR DESCRIPTION
Similar to https://github.com/segmentio/integration-vero/pull/3

At Vero, we would like to show to our users which source does the events come from.
