### PR TITLE
Update group and unsubscribe for parity with server-side integration INT-566

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,10 @@ Vero.prototype.track = function(track) {
   var regex = /[uU]nsubscribe/;
 
   if (track.event().match(regex)) {
-    push('unsubscribe', { id: track.properties().id });
+    var id = this.analytics.user().id();
+    if (id) {
+      push('unsubscribe', id);
+    }
   } else {
     push('track', track.event(), track.properties(), { source: 'segment' });
   }
@@ -117,5 +120,21 @@ Vero.prototype.alias = function(alias) {
     push('reidentify', to, alias.from());
   } else {
     push('reidentify', to);
+  }
+};
+
+Vero.prototype.group = function(group) {
+  var user = this.analytics.user();
+  var traits = {
+    group: group.traits()
+  };
+  if (user.id()) {
+    traits.id = user.id();
+  }
+  if (user.traits().email) {
+    traits.email = user.traits().email;
+  }
+  if (traits.id || traits.email) {
+    push('user', traits);
   }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -139,8 +139,10 @@ describe('Vero', function() {
       });
 
       it('should send an unsubscribe event in the correct format', function() {
-        analytics.track('unsubscribe', { id: 'id' });
-        analytics.called(window._veroq.push, ['unsubscribe', { id: 'id' }]);
+        analytics.identify('id');
+        window._veroq.push.reset();
+        analytics.track('unsubscribe');
+        analytics.called(window._veroq.push, ['unsubscribe', 'id']);
       });
     });
 
@@ -157,6 +159,26 @@ describe('Vero', function() {
       it('should send a new and old id', function() {
         analytics.alias('new', 'old');
         analytics.called(window._veroq.push, ['reidentify', 'new', 'old']);
+      });
+    });
+
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.stub(window._veroq, 'push');
+      });
+
+      it('should send an id and group traits', function() {
+        analytics.identify('id');
+        window._veroq.push.reset();
+        analytics.group('group', { number: 4 });
+        analytics.called(window._veroq.push, ['user', { id: 'id', group: { id: 'group', number: 4 } }]);
+      });
+
+      it('should send an email and group traits', function() {
+        analytics.identify({ email: 'e@ma.il' });
+        window._veroq.push.reset();
+        analytics.group('group', { number: 4 });
+        analytics.called(window._veroq.push, ['user', { email: 'e@ma.il', group: { id: 'group', number: 4 } }]);
       });
     });
   });


### PR DESCRIPTION
The unsubscribe call was non-functioning. I updated it to use the id of the `identify`-d user and send it in the proper format.

The server-side integration calls an undocumented api to update a user with the group traits. We just re-identify the user with the group traits, and vero merges them internally.
